### PR TITLE
Add pointer-events to allow click-thrus

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -72,6 +72,7 @@
     z-index: 10;
     top: 0;
     left: 0;
+    pointer-events: none;
   }
 
   .dark {


### PR DESCRIPTION
Currently, this theme component prevents users from clicking through the bat decorations. This makes critical UI inaccessible. Adding the ```pointer-events: none;``` CSS property to ```.bat-overlay``` fixes this.